### PR TITLE
Hooked up EventRequest in CreateRequest method

### DIFF
--- a/src/GoogleMeasurementProtocol/GoogleAnalyticsRequestFactory.cs
+++ b/src/GoogleMeasurementProtocol/GoogleAnalyticsRequestFactory.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using GoogleMeasurementProtocol.Parameters;
+﻿using GoogleMeasurementProtocol.Parameters;
 using GoogleMeasurementProtocol.Parameters.General;
 using GoogleMeasurementProtocol.Requests;
+using System;
+using System.Collections.Generic;
+using System.Net;
 
 namespace GoogleMeasurementProtocol
 {
@@ -43,16 +43,21 @@ namespace GoogleMeasurementProtocol
         {
             if (hitType == null)
             {
-              throw new ArgumentNullException("hitType");  
+                throw new ArgumentNullException("hitType");
             }
 
             IGoogleAnalyticsRequest request;
 
             switch (hitType.ToLower())
             {
-                case HitTypes.PageView :
+                case HitTypes.PageView:
 
                     request = new PageViewRequest(_useSsl, _proxy);
+                    break;
+
+                case HitTypes.Event:
+
+                    request = new EventRequest(_useSsl, _proxy);
                     break;
 
                 default:


### PR DESCRIPTION
It seems like all hit types have been implemented but not hooked up in the RequestFactory. I needed events to work so added them to the switch statement, using all the EventRequest implementation that was already there. Tested and works. Can't speak for the other hit types but they probably need wiring up as well.

Ps - thanks for this project - exactly what I needed and saved me hours (or days) of work.
