### PR TITLE
Allow all hit types

### DIFF
--- a/src/GoogleMeasurementProtocol/GoogleAnalyticsMeasurementProtocol.csproj
+++ b/src/GoogleMeasurementProtocol/GoogleAnalyticsMeasurementProtocol.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GoogleMeasurementProtocol</RootNamespace>
     <AssemblyName>GoogleMeasurementProtocol</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/GoogleMeasurementProtocol/GoogleAnalyticsMeasurementProtocol.nuspec
+++ b/src/GoogleMeasurementProtocol/GoogleAnalyticsMeasurementProtocol.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>GoogleMeasurementProtocolNet45</id>
+    <version>1.0.0</version>
+    <authors>Kristijan Burnik</authors>
+    <owners>Kristijan Burnik</owners>
+    <licenseUrl>https://github.com/kburnik/google-measurement-protocol-dotnet/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://github.com/kburnik/google-measurement-protocol-dotnet</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+        This is a fork of the original project https://www.nuget.org/packages/GoogleMeasurementProtocol/ from Ion Sapoval
+        retargeted to .NET framework 4.5. Please see the license details when using the library and shipping binaries.
+
+        .Net library for sending Google Analytics Measurement Protocol requests. This library provides support for creating any type of Measurement Protocol request by using any of the existing Measurement Protocol request parameters.</description>
+    <releaseNotes>Retargeting .NET framework version v.4.5</releaseNotes>
+    <copyright>Copyright (c) 2016 Ion Sapoval</copyright>
+    <tags>Google Analytics GoogleMeasurementProtocol</tags>
+  </metadata>
+</package>

--- a/src/GoogleMeasurementProtocol/GoogleAnalyticsMeasurementProtocol.nuspec
+++ b/src/GoogleMeasurementProtocol/GoogleAnalyticsMeasurementProtocol.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>GoogleMeasurementProtocolNet45</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>Kristijan Burnik</authors>
     <owners>Kristijan Burnik</owners>
     <licenseUrl>https://github.com/kburnik/google-measurement-protocol-dotnet/blob/master/LICENSE.TXT</licenseUrl>

--- a/src/GoogleMeasurementProtocol/GoogleAnalyticsRequestFactory.cs
+++ b/src/GoogleMeasurementProtocol/GoogleAnalyticsRequestFactory.cs
@@ -54,6 +54,36 @@ namespace GoogleMeasurementProtocol
 
                     request = new PageViewRequest(_useSsl, _proxy);
                     break;
+                    
+                case HitTypes.Event:
+
+                   request = new EventRequest(_useSsl, _proxy);
+                   break;
+
+               case HitTypes.Item:
+
+                   request = new ItemRequest(_useSsl, _proxy);
+                   break;
+
+               case HitTypes.ScreenView:
+
+                   request = new ScreenTrackingRequest(_useSsl, _proxy);
+                   break;
+
+               case HitTypes.Social:
+
+                   request = new SocialInteractionsRequest(_useSsl, _proxy);
+                   break;
+
+               case HitTypes.Timing:
+
+                   request = new UserTimingTrackingRequest(_useSsl, _proxy);
+                   break;
+
+               case HitTypes.Transaction:
+
+                   request = new TransactionRequest(_useSsl, _proxy);
+                   break;
 
                 default:
                     throw new ApplicationException("Unknown hitType: " + hitType);


### PR DESCRIPTION
We're using this library to send ecommerce transactions server side and we had make this changes to allow "transaction" hittype.

It would be great if you apply this PR to update the NuGet repo.

Thank you.