### PR TITLE
Ability to inject http client to reuse existing connections and avoid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ Install-Package GoogleMeasurementProtocol
 * Connection configuration
 
 ```csharp
-           var webProxy = new WebProxy("http://localhost:8888");
+            var httpClientHandler = new HttpClientHandler
+            {
+                Proxy = new WebProxy("http://localhost:8888"),
+                UseProxy = true
+            };
+            
+            var httpClient = new HttpClient(httpClientHandler)
 
             //Create a factory which will create requests that will use https connection through the given proxy
             var factory = new GoogleAnalyticsRequestFactory("UA-xxxxxxx-x", webProxy);

--- a/src/GoogleMeasurementProtocol_NetStandard/GoogleAnalyticsRequestFactory.cs
+++ b/src/GoogleMeasurementProtocol_NetStandard/GoogleAnalyticsRequestFactory.cs
@@ -16,17 +16,10 @@ namespace GoogleMeasurementProtocol
         private readonly ProtocolVersion _protocolVersion = new ProtocolVersion("1");
         private readonly TrackingId _trackingId;
         private readonly HttpClient _httpClient;
-        private readonly HttpClientHandler _httpClientHandler;
 
-        private GoogleAnalyticsRequestFactory(IWebProxy proxy)
+        private GoogleAnalyticsRequestFactory(HttpClient httpClient)
         {
-            _httpClientHandler = new HttpClientHandler
-            {
-                Proxy = proxy,
-                UseProxy = proxy != null
-            };
-
-            _httpClient = new HttpClient(_httpClientHandler);
+            _httpClient = httpClient ?? new HttpClient();
         }
 
         /// <summary>
@@ -35,8 +28,8 @@ namespace GoogleMeasurementProtocol
         /// It is recommended to have a singleton factory. 
         /// </summary>
         /// <param name="trackingId"></param>
-        /// <param name="proxy"></param>
-        public GoogleAnalyticsRequestFactory(TrackingId trackingId, IWebProxy proxy = null) : this(proxy)
+        /// <param name="httpClient"></param>
+        public GoogleAnalyticsRequestFactory(TrackingId trackingId, HttpClient httpClient = null) : this(httpClient)
         {
             if (trackingId?.Value == null)
             {
@@ -52,8 +45,8 @@ namespace GoogleMeasurementProtocol
         /// It is recommended to have a singleton factory. 
         /// </summary>
         /// <param name="trackingId"></param>
-        /// <param name="proxy"></param>
-        public GoogleAnalyticsRequestFactory(string trackingId, IWebProxy proxy = null) : this(proxy)
+        /// <param name="httpClient"></param>
+        public GoogleAnalyticsRequestFactory(string trackingId, HttpClient httpClient = null) : this(httpClient)
         {
             if (string.IsNullOrEmpty(trackingId))
             {


### PR DESCRIPTION
Possibility to inject HttpClient to GoogleAnalyticsRequestFactory.

In case if service needs to process multiple TrackingIds it requires the creation of multiple 
GoogleAnalyticsRequestFactory which leads to the creation of multiple httpClients. 

Moreover, some users tend to create GoogleAnalyticsRequestFactory each time when they send analytics to google. 
Which leads to HttpClient socket exhaustion, e.g.
https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

The idea is to add the ability to configure HttpClient on the user side. 
